### PR TITLE
Corrected casing of categories and tags to conform with other posts.

### DIFF
--- a/_posts/2022-03-03-things-you-should-know-about-ugc-moderation.md
+++ b/_posts/2022-03-03-things-you-should-know-about-ugc-moderation.md
@@ -5,15 +5,14 @@ author: Blair Ewalt
 author_image: "/images/blog/blair.jpg"
 excerpt_separator: "<!--more-->"
 categories:
-- Online community
+- Online Community
 - Technology
 - Strategies
 tags:
-- User generated content
-- Online safety
-- Profanity filter
-- Moderation tools
-- Best practices
+- user generated content
+- Online Safety
+- Profanity Filter
+- Best Practices
 image: blog/things-to-know-ugc/ugc-header.jpg
 ---
 


### PR DESCRIPTION
Saw these errors 'The following destination is shared by multiple files.'

This was because jekyll turns all tags/cats to lower case but if you have posts with different casing, the plugin is writing to two different files.