### PR TITLE
Add gaming link

### DIFF
--- a/_includes/_product-navigation.html
+++ b/_includes/_product-navigation.html
@@ -1,13 +1,13 @@
 <div data-collapse="none" data-animation="default" data-duration="400" data-ix="fixed-sub-nav" class="cs-fixed-sub-nav-bar-blue w-nav">
   <div class="w-container">
-    <nav role="navigation" class="sub-nav w-clearfix w-nav-menu"><a href="/products/profanity-filter" class="sub-nav-link pp c w-nav-link w--current"></a><a href="/docs/3.x/tech/apis/" class="sub-nav-link cs w-nav-link">API Docs</a><a href="/products/profanity-filter/faqs" class="sub-nav-link cs w-nav-link">FAQs</a>
+    <nav role="navigation" class="sub-nav w-clearfix w-nav-menu"><a href="/products/profanity-filter" class="sub-nav-link pp c w-nav-link w--current"></a><a href="/docs/3.x/tech/apis/" class="sub-nav-link cs w-nav-link">API Docs</a><a href="/products/profanity-filter/faqs" class="sub-nav-link cs w-nav-link">FAQs</a><a href="/gaming" class="sub-nav-link cs w-nav-link">Gaming</a>
       <div class="sub-nav-button w-hidden-small w-hidden-tiny"><a href="/try-cleanspeak" class="orange-button-material small w-button">Get Started</a></div>
     </nav>
   </div>
 </div>
 <div data-collapse="none" data-animation="default" data-duration="400" class="cs-sub-nav-bar _1 w-nav">
   <div class="w-container">
-    <nav role="navigation" class="sub-nav w-clearfix w-nav-menu"><a href="/products/profanity-filter" class="sub-nav-link pp c w-nav-link w--current"></a><a href="/docs/3.x/tech/apis/" class="sub-nav-link cs w-nav-link">API Docs</a><a href="/products/profanity-filter/faqs" class="sub-nav-link cs w-nav-link">FAQs</a>
+    <nav role="navigation" class="sub-nav w-clearfix w-nav-menu"><a href="/products/profanity-filter" class="sub-nav-link pp c w-nav-link w--current"></a><a href="/docs/3.x/tech/apis/" class="sub-nav-link cs w-nav-link">API Docs</a><a href="/products/profanity-filter/faqs" class="sub-nav-link cs w-nav-link">FAQs</a><a href="/gaming" class="sub-nav-link cs w-nav-link">Gaming</a>
       <div class="sub-nav-button w-hidden-small w-hidden-tiny"><a href="/try-cleanspeak" class="orange-button-material small w-button">Get Started</a></div>
     </nav>
   </div>


### PR DESCRIPTION
Note that it points to /gaming, which is an apache redirect not present in jekyll. The content is from /landing/game-developer-conference/ at this time.